### PR TITLE
Implement pickle serialize/deserialize support for ClientOptions, NacosServiceInstance, NacosConfigResponse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ doc = false
 
 [dependencies]
 pyo3 = "0.18"
+bincode = "1.3"
+serde = { version = "1", features = ["derive"] }
+
 
 nacos-sdk = { version = "0.3.5", features = ["default"] }
 #nacos-sdk = { git = "https://github.com/nacos-group/nacos-sdk-rust.git", features = ["default"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,8 @@ fn init_logger() -> &'static tracing_appender::non_blocking::WorkerGuard {
     &LOG_GUARD
 }
 
-#[pyclass]
+/// (module=...) ref: https://github.com/rth/vtext/pull/73#discussion_r439410778
+#[pyclass(module = "nacos_sdk_rust_binding_py")]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ClientOptions {
     /// Server Addr, e.g. address:port[,address:port],...]

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -258,7 +258,7 @@ impl nacos_sdk::api::naming::NamingEventListener for NacosNamingEventListener {
     }
 }
 
-#[pyclass]
+#[pyclass(module = "nacos_sdk_rust_binding_py")]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct NacosServiceInstance {
     /// Instance Id

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -9,7 +9,7 @@ use pyo3::types::PyBytes;
 use serde::{Deserialize, Serialize};
 
 /// Client api of Nacos Naming.
-#[pyclass]
+#[pyclass(module = "nacos_sdk_rust_binding_py")]
 pub struct NacosNamingClient {
     inner: Arc<dyn nacos_sdk::api::naming::NamingService + Send + Sync + 'static>,
 }

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -9,9 +9,12 @@ class Test(unittest.TestCase):
     def test_ClientOptions(self):
         options = ClientOptions(server_addr="127.0.0.1:8848", namespace="")
 
+        self.assert_ClientOptions_pickling(options)
+
+    @staticmethod
+    def assert_ClientOptions_pickling(options: ClientOptions):
         options_pickle = pickle.dumps(options)
         options_unpickle: ClientOptions = pickle.loads(options_pickle)
-
         assert options.server_addr == options_unpickle.server_addr
         assert options.namespace == options_unpickle.namespace
         assert options.app_name == options_unpickle.app_name
@@ -20,12 +23,43 @@ class Test(unittest.TestCase):
         assert options.naming_load_cache_at_start == options_unpickle.naming_load_cache_at_start
         assert options.naming_push_empty_protection == options_unpickle.naming_push_empty_protection
 
+    def test_ClientOptions_all_fields(self):
+        options = ClientOptions(
+            server_addr="127.0.0.1:8848",
+            namespace="namespace",
+            app_name="app_name",
+            username="username",
+            password="password",
+            naming_load_cache_at_start=True,
+            naming_push_empty_protection=True
+        )
+
+        self.assert_ClientOptions_pickling(options)
+
     def test_NacosServiceInstance(self):
         ins = NacosServiceInstance(ip="127.0.0.1", port=8848)
 
+        self.assert_NacosServiceInstance_pickling(ins)
+
+    def test_NacosServiceInstance_all_fields(self):
+        ins = NacosServiceInstance(
+            ip="127.0.0.1",
+            port=8848,
+            weight=1.0,
+            healthy=True,
+            enabled=True,
+            ephemeral=False,
+            cluster_name="cluster_name",
+            service_name="service_name",
+            metadata={"key": "value"}
+        )
+
+        self.assert_NacosServiceInstance_pickling(ins)
+
+    @staticmethod
+    def assert_NacosServiceInstance_pickling(ins: NacosServiceInstance):
         ins_pickle = pickle.dumps(ins)
         ins_unpickle: NacosServiceInstance = pickle.loads(ins_pickle)
-
         assert ins.instance_id == ins_unpickle.instance_id
         assert ins.ip == ins_unpickle.ip
         assert ins.port == ins_unpickle.port

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,0 +1,38 @@
+import pickle
+import unittest
+
+from nacos_sdk_rust_binding_py import ClientOptions, NacosServiceInstance
+
+
+class Test(unittest.TestCase):
+
+    def test_ClientOptions(self):
+        options = ClientOptions(server_addr="127.0.0.1:8848", namespace="")
+
+        options_pickle = pickle.dumps(options)
+        options_unpickle: ClientOptions = pickle.loads(options_pickle)
+
+        assert options.server_addr == options_unpickle.server_addr
+        assert options.namespace == options_unpickle.namespace
+        assert options.app_name == options_unpickle.app_name
+        assert options.username == options_unpickle.username
+        assert options.password == options_unpickle.password
+        assert options.naming_load_cache_at_start == options_unpickle.naming_load_cache_at_start
+        assert options.naming_push_empty_protection == options_unpickle.naming_push_empty_protection
+
+    def test_NacosServiceInstance(self):
+        ins = NacosServiceInstance(ip="127.0.0.1", port=8848)
+
+        ins_pickle = pickle.dumps(ins)
+        ins_unpickle: NacosServiceInstance = pickle.loads(ins_pickle)
+
+        assert ins.instance_id == ins_unpickle.instance_id
+        assert ins.ip == ins_unpickle.ip
+        assert ins.port == ins_unpickle.port
+        assert ins.weight == ins_unpickle.weight
+        assert ins.healthy == ins_unpickle.healthy
+        assert ins.enabled == ins_unpickle.enabled
+        assert ins.ephemeral == ins_unpickle.ephemeral
+        assert ins.cluster_name == ins_unpickle.cluster_name
+        assert ins.service_name == ins_unpickle.service_name
+        assert ins.metadata == ins_unpickle.metadata

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,7 +1,7 @@
 import pickle
 import unittest
 
-from nacos_sdk_rust_binding_py import ClientOptions, NacosServiceInstance
+from nacos_sdk_rust_binding_py import ClientOptions, NacosServiceInstance, NacosConfigResponse
 
 
 class Test(unittest.TestCase):
@@ -36,3 +36,23 @@ class Test(unittest.TestCase):
         assert ins.cluster_name == ins_unpickle.cluster_name
         assert ins.service_name == ins_unpickle.service_name
         assert ins.metadata == ins_unpickle.metadata
+
+    def test_NacosConfigResponse(self):
+        resp = NacosConfigResponse(
+            namespace="namespace",
+            data_id="data_id",
+            group="group",
+            content="content",
+            content_type="content_type",
+            md5="md5",
+        )
+
+        resp_pickle = pickle.dumps(resp)
+        resp_unpickle: NacosConfigResponse = pickle.loads(resp_pickle)
+
+        assert resp.namespace == resp_unpickle.namespace
+        assert resp.data_id == resp_unpickle.data_id
+        assert resp.group == resp_unpickle.group
+        assert resp.content == resp_unpickle.content
+        assert resp.content_type == resp_unpickle.content_type
+        assert resp.md5 == resp_unpickle.md5


### PR DESCRIPTION
如 #2 里讲的一样，把简单的三个结构实现了，测试能通过。
剩下两个Client，Rust会首先抱怨 `serde::{Deserialize, Serialize}` 不支持 `Arc<dyn nacos_sdk::api::naming::XxxService + Send + Sync + 'static>` ，想办法把这个复杂的结构转换成`serde`支持的结构就行，但是超出了我的能力，希望这个PR抛砖引玉。