### PR TITLE
Add python stub file for type annotation hint on developing.

### DIFF
--- a/nacos_sdk_rust_binding_py.pyi
+++ b/nacos_sdk_rust_binding_py.pyi
@@ -1,0 +1,239 @@
+from typing import Callable, Dict, List, NoReturn, Optional
+
+class ClientOptions:
+    def __init__(
+        self,
+        server_addr: str,
+        namespace: str,
+        app_name: Optional[str],
+        username: Optional[str],
+        password: Optional[str],
+        naming_push_empty_protection: Optional[bool],
+        naming_load_cache_at_start: Optional[bool],
+    ) -> None: ...
+
+class NacosConfigResponse:
+    @property
+    def namespace(self) -> str: ...
+    @property
+    def data_id(self) -> str: ...
+    @property
+    def group(self) -> str: ...
+    @property
+    def content(self) -> str: ...
+    @property
+    def content_type(self) -> str: ...
+    @property
+    def md5(self) -> str: ...
+
+class NacosConfigClient:
+    def __init__(self, client_options: ClientOptions) -> None: ...
+    def get_config(self, data_id: str, group: str) -> str:
+        """Get config's content. If it fails, pay attention to err"""
+
+        ...
+    def get_config_resp(self, data_id: str, group: str) -> NacosConfigResponse:
+        """Get NacosConfigResponse. If it fails, pay attention to err"""
+
+        ...
+    def publish_config(self, data_id: str, group: str, content: str) -> bool:
+        """Publish config. If it fails, pay attention to err"""
+
+        ...
+    def remove_config(self, data_id: str, group: str) -> bool:
+        """Remove config. If it fails, pay attention to err"""
+
+        ...
+    def add_listener(
+        self,
+        data_id: str,
+        group: str,
+        listener: Callable[[NacosConfigResponse], NoReturn],
+    ):
+        """Add NacosConfigChangeListener callback func, which listen the config change. If it fails, pay attention to err"""
+
+        ...
+
+class AsyncNacosConfigClient:
+    def __init__(self, client_options: ClientOptions) -> None: ...
+    async def get_config(self, data_id: str, group: str) -> str:
+        """Get config's content. If it fails, pay attention to err"""
+
+        ...
+    async def get_config_resp(self, data_id: str, group: str) -> NacosConfigResponse:
+        """Get NacosConfigResponse. If it fails, pay attention to err"""
+
+        ...
+    async def publish_config(self, data_id: str, group: str, content: str) -> bool:
+        """Publish config. If it fails, pay attention to err"""
+
+        ...
+    async def remove_config(self, data_id: str, group: str) -> bool:
+        """Remove config. If it fails, pay attention to err"""
+
+        ...
+    async def add_listener(
+        self,
+        data_id: str,
+        group: str,
+        listener: Callable[[NacosConfigResponse], NoReturn],
+    ):
+        """Add NacosConfigChangeListener callback func, which listen the config change. If it fails, pay attention to err"""
+
+        ...
+
+class NacosServiceInstance:
+    def __init__(
+        self,
+        ip: str,
+        port: int,
+        weight: Optional[float],
+        healthy: Optional[bool],
+        enabled: Optional[bool],
+        ephemeral: Optional[bool],
+        cluster_name: Optional[str],
+        service_name: Optional[str],
+        metadata: Optional[Dict[str, str]],
+    ) -> None: ...
+
+class NacosNamingClient:
+    def __init__(self, client_options: ClientOptions) -> None: ...
+    def register_instance(
+        self, service_name: str, group: str, service_instance: NacosServiceInstance
+    ):
+        """Register instance. If it fails, pay attention to err"""
+
+        ...
+
+    def deregister_instance(
+        self, service_name: str, group: str, service_instance: NacosServiceInstance
+    ):
+        """Deregister instance. If it fails, pay attention to err"""
+
+        ...
+
+    def batch_register_instance(
+        self,
+        service_name: str,
+        group: str,
+        service_instances: List[NacosServiceInstance],
+    ):
+        """Batch register instance, improve interaction efficiency. If it fails, pay attention to err"""
+
+        ...
+
+    def get_all_instances(
+        self,
+        service_name: str,
+        group: str,
+        clusters: Optional[List[str]],
+        subscribe: Optional[bool],
+    ) -> List[NacosServiceInstance]:
+        """Get all instances by service and group. default cluster=[], subscribe=true. If it fails, pay attention to err"""
+
+        ...
+
+    def select_instances(
+        self,
+        service_name: str,
+        group: str,
+        clusters: Optional[List[str]],
+        subscribe: Optional[bool],
+        healthy: Optional[bool],
+    ) -> List[NacosServiceInstance]:
+        """Select instances whether healthy or not. default cluster=[], subscribe=true, healthy=true. If it fails, pay attention to err"""
+
+        ...
+
+    def select_one_healthy_instance(
+        self,
+        service_name: str,
+        group: str,
+        clusters: Optional[List[str]],
+        subscribe: Optional[bool],
+    ) -> NacosServiceInstance:
+        """Select one healthy instance. default cluster=[], subscribe=true. If it fails, pay attention to err"""
+
+        ...
+
+    def subscribe(
+        self,
+        service_name: str,
+        group: str,
+        clusters: Optional[List[str]],
+        listener: Callable[[NacosConfigResponse], NoReturn],
+    ) -> NacosServiceInstance:
+        """Add NacosNamingEventListener callback func, which listen the instance change. If it fails, pay attention to err"""
+
+        ...
+
+class AsyncNacosNamingClient:
+    def __init__(self, client_options: ClientOptions) -> None: ...
+    async def register_instance(
+        self, service_name: str, group: str, service_instance: NacosServiceInstance
+    ):
+        """Register instance. If it fails, pay attention to err"""
+
+        ...
+
+    async def deregister_instance(
+        self, service_name: str, group: str, service_instance: NacosServiceInstance
+    ):
+        """Deregister instance. If it fails, pay attention to err"""
+
+        ...
+
+    async def batch_register_instance(
+        self,
+        service_name: str,
+        group: str,
+        service_instances: List[NacosServiceInstance],
+    ):
+        """Batch register instance, improve interaction efficiency. If it fails, pay attention to err"""
+
+        ...
+
+    async def get_all_instances(
+        self,
+        service_name: str,
+        group: str,
+        clusters: Optional[List[str]],
+        subscribe: Optional[bool],
+    ) -> List[NacosServiceInstance]:
+        """Get all instances by service and group. default cluster=[], subscribe=true. If it fails, pay attention to err"""
+
+        ...
+
+    async def select_instances(
+        self,
+        service_name: str,
+        group: str,
+        clusters: Optional[List[str]],
+        subscribe: Optional[bool],
+        healthy: Optional[bool],
+    ) -> List[NacosServiceInstance]:
+        """Select instances whether healthy or not. default cluster=[], subscribe=true, healthy=true. If it fails, pay attention to err"""
+
+        ...
+
+    async def select_one_healthy_instance(
+        self,
+        service_name: str,
+        group: str,
+        clusters: Optional[List[str]],
+        subscribe: Optional[bool],
+    ) -> NacosServiceInstance:
+        """Select one healthy instance. default cluster=[], subscribe=true. If it fails, pay attention to err"""
+
+        ...
+
+    async def subscribe(
+        self,
+        service_name: str,
+        group: str,
+        clusters: Optional[List[str]],
+        listener: Callable[[NacosConfigResponse], NoReturn],
+    ) -> NacosServiceInstance:
+        """Add NacosNamingEventListener callback func, which listen the instance change. If it fails, pay attention to err"""
+
+        ...


### PR DESCRIPTION
最近也是恰好需要用到python的nacos sdk，官方的v2维护不够活跃，恰好发现了这个宝藏库🤩，十分感谢作者的贡献。但是在使用过程中，比较盲盒。遂 #5 开启了这个issue，希望添加 `type hints` 辅助。

目前我已经参照 [python-typing-hints](https://pyo3.rs/v0.21.0-beta.0/python-typing-hints) 的建议在项目根目录增加了一个 `nacos_sdk_rust_binding_py.pyi` 文件，自测可以随着 `maturin develop` 

```powershell
📦 Including license file "F:\learning\rust\git\nacos-sdk-rust-binding-py\LICENSE"
🔗 Found pyo3 bindings
🐍 Found CPython 3.12 at F:\learning\rust\git\nacos-sdk-rust-binding-py\.venv\Scripts\python.exe
📡 Using build options features from pyproject.toml
Looking in indexes: https://mirrors.aliyun.com/pypi/simple/
Ignoring pdoc: markers 'extra == "docs"' don't match your environment
Ignoring behave: markers 'extra == "test"' don't match your environment
   Compiling nacos-sdk-rust-binding-py v0.3.6 (F:\learning\rust\git\nacos-sdk-rust-binding-py)
    Finished dev [unoptimized + debuginfo] target(s) in 4.07s
📖 Found type stub file at nacos_sdk_rust_binding_py.pyi   # <--- 自动发现pyi文件
📦 Built wheel for CPython 3.12 to C:\Users\rose\AppData\Local\Temp\.tmpwH57hk\nacos_sdk_rust_binding_py-0.3.6-cp312-none-win_amd64.whl
✏️  Setting installed package as editable
🛠 Installed  nacos-sdk-rust-binding-py-0.3.6
```

在本地环境安装的时候会看到比原本多了一个 `__init__.pyi` 文件，下面是执行了 `maturin develop` 后的安装包目录结构：

```powershell
F:\learning\rust\git\nacos-sdk-rust-binding-py\.venv\Lib\site-packages\nacos_sdk_rust_binding_py
.
├── py.typed (0 B)
├── __init__.pyi (7.5KiB)
├── __init__.py (188 B)
├── nacos_sdk_rust_binding_py.cp312-win_amd64.pyd (16.7MiB)
└── __pycache__
    └── __init__.cpython-312.pyc (390 B)

Summary: Total folders: 1 Total files: 5 Total size: 16.7MiB
```

然后这是在IDE使用的时候，提示的内容:
![image](https://github.com/opc-source/nacos-sdk-rust-binding-py/assets/28704977/a8b13a78-3bfc-46c0-95f5-8a8b4d1df19f)

![image](https://github.com/opc-source/nacos-sdk-rust-binding-py/assets/28704977/ba6877e8-6cb8-4944-9875-6064c1471de6)

此文件仅用于类型的声明，当使用mypy的时候可以为 Python 代码提供静态类型检查，以及优化开发体验。

希望 @CherishCai 可以再次验证，并希望能使得该功能让项目体验更加完美。🙏